### PR TITLE
feat: read user's `PATH ` instead of hard-coded paths

### DIFF
--- a/amenu
+++ b/amenu
@@ -65,8 +65,19 @@ prompt() {
 }
 
 scan_apps() {
-  for program in /usr/bin/* /usr/local/bin/*; do
-    echo "${program##*/}"
+  paths="${PATH}"
+
+  while [ -n "${paths}" ]; do
+    p="${paths%%":"*}"
+    #
+    # Do the string deletion separately since in the last path there will be no ':' suffix.
+    #
+    paths="${paths#"${p}"}"
+    paths="${paths#":"}"
+
+    for program in "${p}/"*; do
+      echo "${program##*/}"
+    done
   done > $FILE_ARGS
 }
 


### PR DESCRIPTION
In the `scan_apps` function, only the paths `/usr/bin` and `/usr/local/bin` are read. Any other paths are ignored by the program: so, no flatpak, no pip, no nix etc.

By reimplementing the aforementioned function, the program now reads all the paths from the user's `PATH` variable, which allows flatpak, pip, nix etc installed programs to show up on the launcher.